### PR TITLE
doc: add binder badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # axi_uartlite_pynq
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/parthpower/axi_uartlite_pynq/HEAD)
+
 PYNQ Compatible Python helper functions for AXI UARTLITE IP Core of Xilinx.
 
 ## UART Config


### PR DESCRIPTION
well, binder doesn't support zynq nor emulated AXI peripheral but something to look forward to :)